### PR TITLE
Use `static inline` to fix building with GCC on Linux

### DIFF
--- a/src/game_config.h
+++ b/src/game_config.h
@@ -81,6 +81,6 @@ static int parse_config(void* user, const char* section, const char* name, const
     return 1;
 }
 
-inline void load_config() {
+static inline void load_config() {
     ini_parse("config.ini", parse_config, NULL);
 }


### PR DESCRIPTION
If you want to have an inlined function definition in a header, you should use `static inline`. Only `inline`, without a linkage specifier, per standard C, has the default function linkage, being `extern`, so that requires a definition in a translation unit (a .c file), like non-`inline`, `extern` functions. Microsoft, as we know, likes to be permissive in what code their compiler accepts, so it seems to produce the `static inline` behavior, despite that being invalid in standard C. Maybe some MSVC strictly-standard compiler option could get MSVC to reject the nonstandard code before this PR.