### PR TITLE
Fix errors and warnings that showed up on Linux

### DIFF
--- a/src/game_config.h
+++ b/src/game_config.h
@@ -66,9 +66,9 @@ section_music_t TITLE_MUSIC = {0};
 static inline bool load_song(const char *file, SDL_AudioSpec *head_format, int16_t **head_data, uint32_t *head_data_len, SDL_AudioSpec *body_format, int16_t **body_data, uint32_t *body_data_len) {
     // Build the new strings.
     const size_t len = SDL_strlen(file) + 20;
-    char *with_h_ogg = calloc(len, sizeof(char));
-    char *with_b_ogg = calloc(len, sizeof(char));
-    char *with_ogg = calloc(len, sizeof(char));
+    char *with_h_ogg = SDL_calloc(len, sizeof(char));
+    char *with_b_ogg = SDL_calloc(len, sizeof(char));
+    char *with_ogg = SDL_calloc(len, sizeof(char));
     SDL_strlcpy(with_h_ogg, "data/", len);
     SDL_strlcpy(with_b_ogg, "data/", len);
     SDL_strlcpy(with_ogg, "data/", len);

--- a/src/main.c
+++ b/src/main.c
@@ -1111,10 +1111,10 @@ SDL_HitTestResult window_hit_test(SDL_Window *win, const SDL_Point *area, void *
     return SDL_HITTEST_DRAGGABLE;
 }
 
-SDL_Texture *load_image(const char* file, void* fallback, const size_t fallback_size) {
+SDL_Texture *load_image(const char* file, const void* fallback, const size_t fallback_size) {
     SDL_Texture *target = IMG_LoadTexture(renderer, file);
     if (target == NULL) {
-        SDL_IOStream *t = SDL_IOFromMem(fallback, fallback_size);
+        SDL_IOStream *t = SDL_IOFromConstMem(fallback, fallback_size);
         target = IMG_LoadTextureTyped_IO(renderer, t, true, "PNG");
     }
     SDL_SetTextureScaleMode(target, SDL_SCALEMODE_NEAREST);


### PR DESCRIPTION
SDL3 doesn't guarantee you get an actual `stdlib.h` inclusion from including SDL3 headers, but does have its own standard library-like functionality in `SDL_stdinc.h`, which includes heap allocation functions; just be sure to use the corresponding SDL3 freeing functions with the memory they allocate. I guess the standard library `calloc()` does end up accessible on Windows/MSVC, but not Linux/GCC.

I also changed the `load_image()` function so the `fallback` data is `const`, as that gets rid of warnings about de-`const`ing the fallback data with `SDL_IOFromMem()`, and in general data inputs should be `const` if it's certain they'll never need to be modified.

Now there's no errors nor warnings when building with GCC on Linux.